### PR TITLE
Enable video file upload

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -9,6 +9,11 @@ yarn dev
 
 depending where you run a relay server for test, you might need to set flags on your browser. see the server instruction for further detail.
 
+### Features
+
+- Supports webcam capture for streaming.
+- Allows uploading a video file, including its audio, for streaming.
+
 <!-- ## Compatibility -->
 <!-- compatible with Draft-04 and have been tested with [Moxygen](https://github.com/facebookexperimental/moxygen) -->
 

--- a/client/src/lib/components/MoQTPublisher.svelte
+++ b/client/src/lib/components/MoQTPublisher.svelte
@@ -45,6 +45,26 @@
     videoEl.srcObject = stream;
     return stream;
   };
+
+  const handleVideoUpload = async (e: Event) => {
+    const input = e.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+    const file = input.files[0];
+    const url = URL.createObjectURL(file);
+    liveEl.srcObject = null;
+    liveEl.src = url;
+    liveEl.muted = false; // ensure audio track is available
+    await liveEl.play();
+    let capture = liveEl.captureStream();
+    // Firefox sometimes omits audio tracks when the element is muted
+    if (capture.getAudioTracks().length === 0) {
+      const audio = new Audio(url);
+      audio.muted = true;
+      await audio.play();
+      capture.addTrack(audio.captureStream().getAudioTracks()[0]);
+    }
+    stream = capture;
+  };
   const connectToServer = async () => {
     if (publisherInit) return;
     publisher = new Publisher({ serverUrl: moqtServerUrl });
@@ -117,6 +137,7 @@
         {/each}
       </select>
     {/if}
+    <input type="file" accept="video/*" on:change={handleVideoUpload} />
   </div>
   <div class="track">
     <div>
@@ -174,6 +195,13 @@
     position: absolute;
     bottom: 10px;
     left: 10px;
+    border: none;
+    padding: 5px 10px;
+  }
+  .pub-video > input[type='file'] {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
     border: none;
     padding: 5px 10px;
   }


### PR DESCRIPTION
## Summary
- allow choosing a video file in `MoQTPublisher.svelte`
- note the new feature in the client README
- ensure uploaded videos stream their audio

## Testing
- `npm test` in `moqtail-core`
- `npm test` in `bytes`
- `npm test` in `client` *(fails: The requested module 'vite' does not provide an export named 'defaultClientConditions')*

------
https://chatgpt.com/codex/tasks/task_e_684a303bbfe8832287dba210e9332c38