### PR TITLE
Fix audio streaming for uploaded videos

### DIFF
--- a/client/src/lib/components/MoQTPublisher.svelte
+++ b/client/src/lib/components/MoQTPublisher.svelte
@@ -88,12 +88,19 @@
       subscribers: [],
       groups: [],
     };
+    const at = stream.getAudioTracks()[0];
+    const settings = at.getSettings ? at.getSettings() : {};
+    const audioEncoderConfig = {
+      ...AUDIO_ENCODER_DEFAULT_CONFIG,
+      ...(settings.sampleRate ? { sampleRate: settings.sampleRate } : {}),
+      ...(settings.channelCount ? { numberOfChannels: settings.channelCount } : {}),
+    } as AudioEncoderConfig;
     const audioTrack: Track = {
       namespace,
       name: audioTrackName,
       type: 'audio',
       objectForwardingPrefereces: 'Datagram',
-      encoderConfig: { encoderConfig: AUDIO_ENCODER_DEFAULT_CONFIG, keyFrameDuration },
+      encoderConfig: { encoderConfig: audioEncoderConfig, keyFrameDuration },
       groupOrderPublisherPreference: GROUP_ORDER.ASCENDING,
       subscribers: [],
       groups: [],
@@ -103,7 +110,6 @@
     const vt = stream.getVideoTracks()[0];
     Mogger.info(`Streaming ${vt.label}`);
     publisher.startStream({ track: videoTrack, mediaTrack: vt });
-    const at = stream.getAudioTracks()[0];
     console.log(at);
     Mogger.info(`Streaming ${at.label}`);
     publisher.startStream({ track: audioTrack, mediaTrack: at });


### PR DESCRIPTION
## Summary
- adjust audio encoder settings to match uploaded video tracks

## Testing
- `npm test` in `moqtail-core`
- `npm test` in `bytes`
- ❌ `yarn workspace client test` *(fails: The requested module 'vite' does not provide an export named 'defaultClientConditions')*

------
https://chatgpt.com/codex/tasks/task_e_684c16f7a10c83229c67e5ac241f20ac