### PR TITLE
Add bitrate metric to statistics

### DIFF
--- a/client/src/lib/components/Statistics.svelte
+++ b/client/src/lib/components/Statistics.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { moqVideoTransmissionLatencyStore } from '$lib/utils/store';
+  import { moqVideoTransmissionLatencyStore, bitrateStore } from '$lib/utils/store';
   import { Mogger } from '$lib/utils/mogger';
 
   let cpuLoad = 'Compute Pressure API not supported';
@@ -28,6 +28,10 @@
     <div class="stat-item">
       <span class="stat-label">CPU Load:</span>
       <span class="stat-value">{cpuLoad}</span>
+    </div>
+    <div class="stat-item">
+      <span class="stat-label">Bitrate:</span>
+      <span class="stat-value">{$bitrateStore} bps</span>
     </div>
   </div>
 </div>

--- a/client/src/lib/components/Statistics.svelte
+++ b/client/src/lib/components/Statistics.svelte
@@ -31,7 +31,7 @@
     </div>
     <div class="stat-item">
       <span class="stat-label">Bitrate:</span>
-      <span class="stat-value">{$bitrateStore} bps</span>
+      <span class="stat-value">{($bitrateStore / 1_000_000).toFixed(2)} Mbps</span>
     </div>
   </div>
 </div>

--- a/client/src/lib/subscriber.ts
+++ b/client/src/lib/subscriber.ts
@@ -1,7 +1,7 @@
 import { Mogger } from './utils/mogger';
 import { CONTROL_MESSAGE, deserializeVideoDecoderConfig, LOC_EXTENSION_HEADER_TYPE, MOQT_DRAFT08_VERSION, MOQT_DRAFT09_VERSION, MOQT_DRAFT10_VERSION, serializeClientSetup, serializeSubscribe, STREAM, deserializeAudioDecoderConfig, serializeUnsubscribe, OBJECT_STATUS, deserializeDatagramFragmentInfo, deserializeEncodedChunkFromArray } from 'moqtail';
 import type { Subscribe, ServerSetup, SubscribeOk, SubgroupHeader, SubgroupObject, SubscribeError, Datagram } from 'moqtail';
-import { moqVideoTransmissionLatencyStore, ringStats } from './utils/store';
+import { moqVideoTransmissionLatencyStore, ringStats, bitrateStore } from './utils/store';
 
 import { DatagramBuffer, BufferedDatagram } from "./utils/datagramBuffer";
 import { concatUint8Arrays } from "bytes";
@@ -28,6 +28,8 @@ export class Subscriber {
   private datagramBuffer = new DatagramBuffer();
   private datagramFragments: Map<string, { total: number; payloads: Uint8Array[]; header: Datagram }> = new Map();
   private videoTimestampOffset: number | null = null;
+  private receivedBytes = 0;
+  private bitrateInterval: number;
   private audioNode: AudioWorkletNode;
   private communicator: Worker;
   private videoRenderer: Worker = new VideoRendererWorker();
@@ -35,6 +37,10 @@ export class Subscriber {
     this.communicator = new CommunicatorWorker();
     this.communicator.onmessage = this.communicatorMessageHandler.bind(this);
     this.communicator.postMessage({ type: 'startConnection', data: props.serverUrl });
+    this.bitrateInterval = setInterval(() => {
+      bitrateStore.set(this.receivedBytes * 8);
+      this.receivedBytes = 0;
+    }, 1000);
   }
   setup() {
     this.communicator.postMessage({ type: 'startReadLoop', data: null });
@@ -177,6 +183,7 @@ export class Subscriber {
         }
       });
       const chunk = new EncodedVideoChunk(encodedChunkInit);
+      this.receivedBytes += encodedChunkInit.data.byteLength;
       sub.decoder.postMessage({ type: 'decode', data: { encodedVideoChunk: chunk, config: videoDecoderConfig } });
 
       if (groupId !== undefined) {
@@ -245,6 +252,7 @@ export class Subscriber {
         });
         
         const audioChunk = new EncodedAudioChunk(datagramObject.encodedChunkInit as EncodedAudioChunkInit);
+        this.receivedBytes += (datagramObject.encodedChunkInit as EncodedAudioChunkInit).data.byteLength;
         sub.decoder.postMessage({ type: 'decode', data: { encodedAudioChunk: audioChunk, config: audioDecoderConfig } });
       }
       break;
@@ -292,6 +300,7 @@ export class Subscriber {
         }
       });
       const vChunk = new EncodedVideoChunk(d.encodedChunkInit as EncodedVideoChunkInit);
+      this.receivedBytes += (d.encodedChunkInit as EncodedVideoChunkInit).data.byteLength;
       sub.decoder.postMessage({ type: 'decode', data: { encodedVideoChunk: vChunk, config: vConfig } });
     }
   }

--- a/client/src/lib/utils/store.ts
+++ b/client/src/lib/utils/store.ts
@@ -7,3 +7,5 @@ export const ringStats = writable<RingBufferStats>({
   writePos: 0,
   readPos: 0
 });
+
+export const bitrateStore = writable<number>(0);


### PR DESCRIPTION
## Summary
- provide bitrate store for the UI
- show bitrate in the Statistics widget
- track received bytes in the subscriber to update the bitrate store

## Testing
- `npx jest -c moqtail-core/jest.config.js`
- `npx jest -c bytes/jest.config.js`

------
https://chatgpt.com/codex/tasks/task_e_684cf5f2fc2c8322878a88f099c4f06d