### PR TITLE
Add install target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: install prod dev
+
+install:
+	yarn install
+
+prod:
+	yarn --cwd bytes build
+	yarn --cwd moqtail-core build
+	yarn --cwd client build
+
+
+dev:
+	yarn --cwd bytes build
+	yarn --cwd moqtail-core build
+	yarn --cwd client dev

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## moqtail
 moqtail is a client implementation of Media over QUIC Transport protocol (MoQT).
 
-This is the root directory of the moqtail projects. The core library lives under the `moqtail-core` workspace. Run `yarn install` to create symbolic links so you can develop the client and core packages together.
+This is the root directory of the moqtail projects. The core library lives under the `moqtail-core` workspace. Run `make install` to create symbolic links so you can develop the client and core packages together.
 
 ### Repository Structure
 
@@ -15,3 +15,13 @@ This is the root directory of the moqtail projects. The core library lives under
 
 - **moqtail-core/**
   - The main core library, providing serializers/deserializers for MOQT control messages, data streams, and packagers.
+
+### Build Commands
+
+Use the Makefile to manage development and production builds:
+
+```bash
+make install   # install workspace dependencies
+make prod      # build all workspaces for production
+make dev       # build libraries and start the client in dev mode
+```


### PR DESCRIPTION
## Summary
- update Makefile so `prod` and `dev` no longer run `yarn install`
- add separate `install` rule
- document usage in the README

## Testing
- `yarn --cwd bytes test` *(fails: package not in lockfile)*
- `yarn --cwd moqtail-core test` *(fails: package not in lockfile)*
- `yarn --cwd client test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684d01b175208322bba21babdb939409