### PR TITLE
Replace canvas subscriber with video element

### DIFF
--- a/client/src/lib/components/MoQTSubscriber.svelte
+++ b/client/src/lib/components/MoQTSubscriber.svelte
@@ -2,15 +2,15 @@
   import { Subscriber } from '$lib/subscriber';
   import { GROUP_ORDER, type Subscribe, SUBSCRIBE_FILTER } from 'moqtail';
 
-  let canvasEl: HTMLCanvasElement;
+  let videoEl: HTMLVideoElement;
   let moqIsPlaying = false;
   let subscriberInit = false;
   let subscriber: Subscriber;
   let setupSent = false;
 
   export let moqtServerUrl;
-  export let canvasWidth = 480;
-  export let canvasHeight = 360;
+  export let videoWidth = 480;
+  export let videoHeight = 360;
   let namespace = ['moqtail'];
   let videoTrackName = 'video0';
   let audioTrackName = 'audio0';
@@ -25,7 +25,7 @@
       jitterBufferFrameSize: jitterBufferSize,
     });
     subscriberInit = true;
-    subscriber.setCanvasElement(canvasEl);
+    subscriber.setVideoElement(videoEl);
     subscriber.setAudioContext();
   };
   const setup = () => {
@@ -61,15 +61,15 @@
     subscriber.unsubscribe(audioTrackName);
     subscriber.stopAudio();
   };
-  const canvasGoFullscreen = () => {
-    canvasEl.requestFullscreen();
+  const videoGoFullscreen = () => {
+    videoEl.requestFullscreen();
   };
 </script>
 
 <div class="sub">
   <h3>Subscriber</h3>
-  <canvas width={canvasWidth} height={canvasHeight} bind:this={canvasEl} />
-  <button on:click={canvasGoFullscreen}>Go Fullscreen</button>
+  <video width={videoWidth} height={videoHeight} autoplay bind:this={videoEl}></video>
+  <button on:click={videoGoFullscreen}>Go Fullscreen</button>
   <div class="track">
     <div>
       <label for="pub-track-namespace">Track Namespace</label>
@@ -109,7 +109,7 @@
     justify-content: start;
     align-items: center;
   }
-  canvas {
+  video {
     background-color: #333;
   }
   fieldset {

--- a/client/src/lib/subscriber.ts
+++ b/client/src/lib/subscriber.ts
@@ -33,6 +33,8 @@ export class Subscriber {
   private audioNode: AudioWorkletNode;
   private communicator: Worker;
   private videoRenderer: Worker = new VideoRendererWorker();
+  private videoGenerator?: MediaStreamTrackGenerator;
+  private videoWriter?: WritableStreamDefaultWriter<VideoFrame>;
   constructor(props: SubscriberInitProps) {
     this.communicator = new CommunicatorWorker();
     this.communicator.onmessage = this.communicatorMessageHandler.bind(this);
@@ -69,6 +71,12 @@ export class Subscriber {
   setCanvasElement(canvasElement: HTMLCanvasElement) {
     const offscreen = canvasElement.transferControlToOffscreen();
     this.videoRenderer.postMessage({ type: 'init', data: { canvas: offscreen } }, [offscreen]);
+  }
+  setVideoElement(videoElement: HTMLVideoElement) {
+    this.videoGenerator = new MediaStreamTrackGenerator({ kind: 'video' });
+    const stream = new MediaStream([this.videoGenerator]);
+    videoElement.srcObject = stream;
+    this.videoWriter = this.videoGenerator.writable.getWriter();
   }
   async setAudioContext() {
     const audioCtx = new AudioContext({ sampleRate: 48000 }); // TODO: use the sample rate from the server
@@ -265,7 +273,11 @@ export class Subscriber {
     switch (message.data.type) {
     case 'videoFrame':
       const vfData = message.data.data as { subscribeId: number, frame: VideoFrame };
-      this.videoRenderer.postMessage({ type: 'frame', data: vfData.frame }, [vfData.frame]);
+      if (this.videoWriter) {
+        this.videoWriter.write(vfData.frame).then(() => vfData.frame.close());
+      } else {
+        this.videoRenderer.postMessage({ type: 'frame', data: vfData.frame }, [vfData.frame]);
+      }
       break;
     case 'audioData':
       const ad = message.data.data.audioData as AudioData;

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -24,7 +24,7 @@
       <MoQtPublisher {moqtServerUrl} />
     </div>
     <div class="right">
-      <MoQTSubscriber {moqtServerUrl} canvasWidth={480} canvasHeight={360} />
+      <MoQTSubscriber {moqtServerUrl} videoWidth={480} videoHeight={360} />
     </div>
   </div>
   <div class="container-statistics">


### PR DESCRIPTION
## Summary
- switch subscriber view to use `<video>` instead of `<canvas>`
- add a `setVideoElement` helper in the subscriber library
- update the demo page to pass video dimensions

## Testing
- `yarn --cwd moqtail-core test`
- `yarn --cwd client test` *(fails: Startup Error)*

------
https://chatgpt.com/codex/tasks/task_e_684d6df7fdc4832289c12469696321f2