### PR TITLE
Support separate webcam and upload tracks

### DIFF
--- a/client/src/lib/components/MoQTPublisher.svelte
+++ b/client/src/lib/components/MoQTPublisher.svelte
@@ -5,11 +5,15 @@
   import { GROUP_ORDER } from 'moqtail';
   import { onMount } from 'svelte';
 
-  let liveEl: HTMLVideoElement;
+  let liveEl: HTMLVideoElement; // webcam preview
+  let uploadEl: HTMLVideoElement; // uploaded video preview
   let publisherInit = false;
   let setupSent = false;
   let publisher: Publisher;
-  let stream: MediaStream;
+  let camStream: MediaStream;
+  let uploadStream: MediaStream;
+  let camStreaming = false;
+  let uploadStreaming = false;
 
   const videoEncoders = {
     h264: VIDEO_ENCODER_MOQMI_CONFIG,
@@ -27,6 +31,8 @@
   let namespace = ['moqtail'];
   let videoTrackName = 'video0';
   let audioTrackName = 'audio0';
+  let uploadedVideoTrackName = 'video1';
+  let uploadedAudioTrackName = 'audio1';
   let keyFrameDuration = 30;
 
   const camera = {
@@ -50,15 +56,15 @@
   };
 
   const changeResolution = async () => {
-    if (stream) {
-      stream.getTracks().forEach((t) => t.stop());
+    if (camStream) {
+      camStream.getTracks().forEach((t) => t.stop());
     }
-    stream = await navigator.mediaDevices
+    camStream = await navigator.mediaDevices
       .getUserMedia({ video: videoResolutions[videoResolutionChoice], audio: true })
       .catch(() => {
         throw new Error('Error accessing media devices:');
       });
-    setLiveVideo(stream, liveEl);
+    setLiveVideo(camStream, liveEl);
   };
 
   const handleVideoUpload = async (e: Event) => {
@@ -66,12 +72,12 @@
     if (!input.files || input.files.length === 0) return;
     const file = input.files[0];
     const url = URL.createObjectURL(file);
-    liveEl.srcObject = null;
-    liveEl.src = url;
+    uploadEl.srcObject = null;
+    uploadEl.src = url;
     // unmute temporarily to ensure the audio track is captured
-    liveEl.muted = false;
-    await liveEl.play();
-    let capture = liveEl.captureStream();
+    uploadEl.muted = false;
+    await uploadEl.play();
+    let capture = uploadEl.captureStream();
     // Firefox sometimes omits audio tracks when the element is muted
     if (capture.getAudioTracks().length === 0) {
       const audio = new Audio(url);
@@ -79,9 +85,9 @@
       await audio.play();
       capture.addTrack(audio.captureStream().getAudioTracks()[0]);
     }
-    stream = capture;
+    uploadStream = capture;
     // do not play the source audio locally
-    liveEl.muted = true;
+    uploadEl.muted = true;
   };
   const connectToServer = async () => {
     if (publisherInit) return;
@@ -93,54 +99,108 @@
     publisher.setup();
     setupSent = true;
   };
-  const startStreaming = () => {
+  const startCamStreaming = () => {
     if (!publisherInit) return;
     publisher.announce(namespace);
     const videoEncoderConfig = {
       ...videoEncoders[videoEncoderChoice],
       ...videoResolutions[videoResolutionChoice],
     };
-    const videoTrack: Track = {
-      namespace,
-      name: videoTrackName,
-      type: 'video',
-      objectForwardingPrefereces: videoForwardingPreference,
-      encoderConfig: { encoderConfig: videoEncoderConfig, keyFrameDuration },
-      groupOrderPublisherPreference: GROUP_ORDER.ASCENDING,
-      subscribers: [],
-      groups: [],
+    if (camStream && !camStreaming) {
+      const videoTrack: Track = {
+        namespace,
+        name: videoTrackName,
+        type: 'video',
+        objectForwardingPrefereces: videoForwardingPreference,
+        encoderConfig: { encoderConfig: videoEncoderConfig, keyFrameDuration },
+        groupOrderPublisherPreference: GROUP_ORDER.ASCENDING,
+        subscribers: [],
+        groups: [],
+      };
+      const at = camStream.getAudioTracks()[0];
+      const settings = at.getSettings ? at.getSettings() : {};
+      const audioEncoderConfig = {
+        ...AUDIO_ENCODER_DEFAULT_CONFIG,
+        ...(settings.sampleRate ? { sampleRate: settings.sampleRate } : {}),
+        ...(settings.channelCount ? { numberOfChannels: settings.channelCount } : {}),
+      } as AudioEncoderConfig;
+      const audioTrack: Track = {
+        namespace,
+        name: audioTrackName,
+        type: 'audio',
+        objectForwardingPrefereces: 'Datagram',
+        encoderConfig: { encoderConfig: audioEncoderConfig, keyFrameDuration },
+        groupOrderPublisherPreference: GROUP_ORDER.ASCENDING,
+        subscribers: [],
+        groups: [],
+        largestGroupId: -1,
+        largestObjectId: -1,
+      };
+      const vt = camStream.getVideoTracks()[0];
+      Mogger.info(`Streaming ${vt.label}`);
+      publisher.startStream({ track: videoTrack, mediaTrack: vt });
+      Mogger.info(`Streaming ${at.label}`);
+      publisher.startStream({ track: audioTrack, mediaTrack: at });
+      camStreaming = true;
+    }
+  };
+
+  const startUploadStreaming = () => {
+    if (!publisherInit || !uploadStream || uploadStreaming) return;
+    const videoEncoderConfig = {
+      ...videoEncoders[videoEncoderChoice],
+      ...videoResolutions[videoResolutionChoice],
     };
-    const at = stream.getAudioTracks()[0];
-    const settings = at.getSettings ? at.getSettings() : {};
-    const audioEncoderConfig = {
-      ...AUDIO_ENCODER_DEFAULT_CONFIG,
-      ...(settings.sampleRate ? { sampleRate: settings.sampleRate } : {}),
-      ...(settings.channelCount ? { numberOfChannels: settings.channelCount } : {}),
-    } as AudioEncoderConfig;
-    const audioTrack: Track = {
-      namespace,
-      name: audioTrackName,
-      type: 'audio',
-      objectForwardingPrefereces: 'Datagram',
-      encoderConfig: { encoderConfig: audioEncoderConfig, keyFrameDuration },
-      groupOrderPublisherPreference: GROUP_ORDER.ASCENDING,
-      subscribers: [],
-      groups: [],
-      largestGroupId: -1,
-      largestObjectId: -1,
-    };
-    const vt = stream.getVideoTracks()[0];
-    Mogger.info(`Streaming ${vt.label}`);
-    publisher.startStream({ track: videoTrack, mediaTrack: vt });
-    Mogger.info(`Streaming ${at.label}`);
-    publisher.startStream({ track: audioTrack, mediaTrack: at });
+    {
+      const videoTrackFile: Track = {
+        namespace,
+        name: uploadedVideoTrackName,
+        type: 'video',
+        objectForwardingPrefereces: videoForwardingPreference,
+        encoderConfig: { encoderConfig: videoEncoderConfig, keyFrameDuration },
+        groupOrderPublisherPreference: GROUP_ORDER.ASCENDING,
+        subscribers: [],
+        groups: [],
+      };
+      const atf = uploadStream.getAudioTracks()[0];
+      const settingsF = atf.getSettings ? atf.getSettings() : {};
+      const audioEncoderConfigFile = {
+        ...AUDIO_ENCODER_DEFAULT_CONFIG,
+        ...(settingsF.sampleRate ? { sampleRate: settingsF.sampleRate } : {}),
+        ...(settingsF.channelCount ? { numberOfChannels: settingsF.channelCount } : {}),
+      } as AudioEncoderConfig;
+      const audioTrackFile: Track = {
+        namespace,
+        name: uploadedAudioTrackName,
+        type: 'audio',
+        objectForwardingPrefereces: 'Datagram',
+        encoderConfig: { encoderConfig: audioEncoderConfigFile, keyFrameDuration },
+        groupOrderPublisherPreference: GROUP_ORDER.ASCENDING,
+        subscribers: [],
+        groups: [],
+        largestGroupId: -1,
+        largestObjectId: -1,
+      };
+      const vtF = uploadStream.getVideoTracks()[0];
+      Mogger.info(`Streaming ${vtF.label}`);
+      publisher.startStream({ track: videoTrackFile, mediaTrack: vtF });
+      Mogger.info(`Streaming ${atf.label}`);
+      publisher.startStream({ track: audioTrackFile, mediaTrack: atf });
+      uploadStreaming = true;
+    }
   };
   const stopStreaming = () => {
     if (!publisherInit) return;
-    publisher.stopStream(videoTrackName);
-    publisher.stopStream(audioTrackName);
-    // publisher.unannounce(namespace);
-    publisherInit = false;
+    if (camStreaming) {
+      publisher.stopStream(videoTrackName);
+      publisher.stopStream(audioTrackName);
+      camStreaming = false;
+    }
+    if (uploadStreaming) {
+      publisher.stopStream(uploadedVideoTrackName);
+      publisher.stopStream(uploadedAudioTrackName);
+      uploadStreaming = false;
+    }
   };
 
   onMount(async () => {
@@ -163,6 +223,9 @@
       </select>
     {/if}
   </div>
+  <div class="pub-video">
+    <video autoplay muted playsinline controls bind:this={uploadEl}></video>
+  </div>
   <input class="file-upload" type="file" accept="video/*" on:change={handleVideoUpload} />
   <div class="track">
     <div>
@@ -176,6 +239,14 @@
     <div>
       <label for="pub-track-audio">Audio Track Name</label>
       <input type="text" name="pub-track-audio" bind:value={audioTrackName} />
+    </div>
+    <div>
+      <label for="pub-upload-video">Uploaded Video Track Name</label>
+      <input type="text" name="pub-upload-video" bind:value={uploadedVideoTrackName} />
+    </div>
+    <div>
+      <label for="pub-upload-audio">Uploaded Audio Track Name</label>
+      <input type="text" name="pub-upload-audio" bind:value={uploadedAudioTrackName} />
     </div>
     <div>
       <label for="pub-track-keyframe-duration">Key Frame Duration {keyFrameDuration}</label>
@@ -210,8 +281,9 @@
   </div>
   <button on:click={async () => await connectToServer()}>Connect to server</button>
   <button on:click={async () => setup()}>Setup</button>
-  <button on:click={async () => startStreaming()}>Start streaming</button>
-  <button on:click={async () => stopStreaming()}>Stop streaming</button>
+  <button on:click={startCamStreaming}>Start camera streaming</button>
+  <button on:click={startUploadStreaming}>Start file streaming</button>
+  <button on:click={stopStreaming}>Stop streaming</button>
 </div>
 
 <style>
@@ -227,6 +299,9 @@
   }
   .pub-video > video {
     object-fit: contain;
+  }
+  .pub-video + .pub-video {
+    margin-top: 10px;
   }
   .pub-video > select {
     position: absolute;

--- a/client/src/lib/components/MoQTSubscriber.svelte
+++ b/client/src/lib/components/MoQTSubscriber.svelte
@@ -11,9 +11,9 @@
   export let moqtServerUrl;
   export let videoWidth = 480;
   export let videoHeight = 360;
-  let namespace = ['moqtail'];
-  let videoTrackName = 'video0';
-  let audioTrackName = 'audio0';
+  export let namespace = ['moqtail'];
+  export let videoTrackName = 'video0';
+  export let audioTrackName = 'audio0';
   let jitterBufferSize = 10;
 
   // let videoQuality: 'low' | 'medium' | 'high' = 'low';

--- a/client/src/routes/+page.svelte
+++ b/client/src/routes/+page.svelte
@@ -28,6 +28,13 @@
     </div>
     <div class="right">
       <MoQTSubscriber {moqtServerUrl} videoWidth={480} videoHeight={360} />
+      <MoQTSubscriber
+        {moqtServerUrl}
+        videoWidth={480}
+        videoHeight={360}
+        videoTrackName="video1"
+        audioTrackName="audio1"
+      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- allow customizing track names for subscriber
- publish uploaded file on separate video/audio tracks
- preview uploaded file alongside webcam
- subscribe to extra tracks on the demo page
- allow starting uploaded stream independently of webcam

## Testing
- `yarn --cwd client test` *(fails: defaultClientConditions export missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ec5376eac8322b3908e5bc8c754dc