### PR TITLE
Implement media track replacement in streaming

### DIFF
--- a/client/src/lib/components/MoQTPublisher.svelte
+++ b/client/src/lib/components/MoQTPublisher.svelte
@@ -80,6 +80,12 @@
       capture.addTrack(audio.captureStream().getAudioTracks()[0]);
     }
     stream = capture;
+    if (publisherInit) {
+      const vt = stream.getVideoTracks()[0];
+      if (vt) publisher.replaceMediaTrack(videoTrackName, vt);
+      const at = stream.getAudioTracks()[0];
+      if (at) publisher.replaceMediaTrack(audioTrackName, at);
+    }
     // do not play the source audio locally
     liveEl.muted = true;
   };

--- a/client/src/lib/publisher.ts
+++ b/client/src/lib/publisher.ts
@@ -68,6 +68,41 @@ export class Publisher {
       this.audioEncoders[track.name].postMessage({ type: 'capture', data: processor.readable }, [processor.readable]);
     }
   }
+
+  replaceMediaTrack(trackName: string, mediaTrack: MediaStreamTrack) {
+    const track = this.trackManager.getTrack({ name: trackName });
+    if (!track) {
+      Mogger.error(`Track ${trackName} not found`);
+      return;
+    }
+    if (track.type === 'video') {
+      if (this.videoEncoders[track.name]) {
+        this.videoEncoders[track.name].postMessage({ type: 'stop', data: null });
+        this.videoEncoders[track.name].terminate();
+      }
+      this.videoEncoders[track.name] = new VideoEncoderWorker();
+      this.videoEncoders[track.name].onmessage = this.videoEncoderMessageHandler.bind(this);
+      this.videoEncoders[track.name].postMessage({ type: 'init', data: track });
+      const processor = new MediaStreamTrackProcessor({ track: mediaTrack as MediaStreamVideoTrack });
+      this.videoEncoders[track.name].postMessage({ type: 'capture', data: processor.readable }, [processor.readable]);
+      if (track.subscribers.length > 0) {
+        this.videoEncoders[track.name].postMessage({ type: 'encode', data: null });
+      }
+    } else if (track.type === 'audio') {
+      if (this.audioEncoders[track.name]) {
+        this.audioEncoders[track.name].postMessage({ type: 'stop', data: null });
+        this.audioEncoders[track.name].terminate();
+      }
+      this.audioEncoders[track.name] = new AudioEncoderWorker();
+      this.audioEncoders[track.name].onmessage = this.audioEncoderMessageHandler.bind(this);
+      this.audioEncoders[track.name].postMessage({ type: 'init', data: track });
+      const processor = new MediaStreamTrackProcessor({ track: mediaTrack as MediaStreamAudioTrack });
+      this.audioEncoders[track.name].postMessage({ type: 'capture', data: processor.readable }, [processor.readable]);
+      if (track.subscribers.length > 0) {
+        this.audioEncoders[track.name].postMessage({ type: 'encode', data: null });
+      }
+    }
+  }
   stopStream(trackName: string) {
     const track = this.trackManager.getTrack({ name: trackName });
     if (!track) {


### PR DESCRIPTION
## Summary
- add `replaceMediaTrack` to recreate encoder workers with new MediaStreamTracks
- trigger replacement when a video file is uploaded in `MoQTPublisher`

## Testing
- `yarn install`
- `yarn workspace client test` *(fails: Startup Error due to missing peer deps)*

------
https://chatgpt.com/codex/tasks/task_e_684ed350659883229e283bf70796c7a4