### PR TITLE
Add ASCII art playback

### DIFF
--- a/client/src/lib/components/MoQTSubscriber.svelte
+++ b/client/src/lib/components/MoQTSubscriber.svelte
@@ -7,6 +7,7 @@
   let subscriberInit = false;
   let subscriber: Subscriber;
   let setupSent = false;
+  let asciiEl: HTMLElement;
 
   export let moqtServerUrl;
   export let videoWidth = 480;
@@ -26,6 +27,7 @@
     });
     subscriberInit = true;
     subscriber.setVideoElement(videoEl);
+    subscriber.setAsciiElement(asciiEl);
     subscriber.setAudioContext();
   };
   const setup = () => {
@@ -66,6 +68,7 @@
 <div class="sub">
   <h3>Subscriber</h3>
   <video width={videoWidth} height={videoHeight} autoplay controls bind:this={videoEl}></video>
+  <pre class="ascii" bind:this={asciiEl}></pre>
   <div class="track">
     <div>
       <label for="pub-track-namespace">Track Namespace</label>
@@ -107,5 +110,10 @@
   }
   video {
     background-color: #333;
+  }
+  .ascii {
+    font-family: monospace;
+    line-height: 1;
+    white-space: pre;
   }
 </style>

--- a/client/src/lib/components/MoQTSubscriber.svelte
+++ b/client/src/lib/components/MoQTSubscriber.svelte
@@ -64,9 +64,12 @@
     subscriber.stopAudio();
   };
 
-  const toggleAscii = () => {
+  import { tick } from 'svelte';
+
+  const toggleAscii = async () => {
     if (!subscriber) return;
     asciiMode = !asciiMode;
+    await tick();
     if (asciiMode) {
       const width = 80;
       const height = Math.round(width * videoHeight / videoWidth);

--- a/client/src/lib/components/MoQTSubscriber.svelte
+++ b/client/src/lib/components/MoQTSubscriber.svelte
@@ -8,6 +8,7 @@
   let subscriber: Subscriber;
   let setupSent = false;
   let asciiEl: HTMLElement;
+  let asciiMode = false;
 
   export let moqtServerUrl;
   export let videoWidth = 480;
@@ -27,7 +28,6 @@
     });
     subscriberInit = true;
     subscriber.setVideoElement(videoEl);
-    subscriber.setAsciiElement(asciiEl);
     subscriber.setAudioContext();
   };
   const setup = () => {
@@ -63,12 +63,27 @@
     subscriber.unsubscribe(audioTrackName);
     subscriber.stopAudio();
   };
+
+  const toggleAscii = () => {
+    if (!subscriber) return;
+    asciiMode = !asciiMode;
+    if (asciiMode) {
+      const width = 80;
+      const height = Math.round(width * videoHeight / videoWidth);
+      subscriber.setAsciiElement(asciiEl, width, height);
+    } else {
+      subscriber.setAsciiElement();
+    }
+  };
 </script>
 
 <div class="sub">
   <h3>Subscriber</h3>
-  <video width={videoWidth} height={videoHeight} autoplay controls bind:this={videoEl}></video>
-  <pre class="ascii" bind:this={asciiEl}></pre>
+  {#if asciiMode}
+    <pre class="ascii" bind:this={asciiEl}></pre>
+  {:else}
+    <video width={videoWidth} height={videoHeight} autoplay controls bind:this={videoEl}></video>
+  {/if}
   <div class="track">
     <div>
       <label for="pub-track-namespace">Track Namespace</label>
@@ -98,6 +113,7 @@
   <button on:click={setup}>Setup</button>
   <button on:click={playStream}>Start playback</button>
   <button on:click={stopStream}>Stop playback</button>
+  <button on:click={toggleAscii}>{asciiMode ? 'Go video' : 'Go ASCII'}</button>
 </div>
 
 <style>

--- a/client/src/lib/subscriber.ts
+++ b/client/src/lib/subscriber.ts
@@ -5,6 +5,7 @@ import { moqVideoTransmissionLatencyStore, ringStats, bitrateStore } from './uti
 
 import { DatagramBuffer, BufferedDatagram } from "./utils/datagramBuffer";
 import { concatUint8Arrays } from "bytes";
+import { frameToAscii } from './utils/ascii';
 
 // @ts-ignore
 import CommunicatorWorker from './threads/communicator.worker?worker';
@@ -33,6 +34,9 @@ export class Subscriber {
   private communicator: Worker;
   private videoGenerator?: MediaStreamTrackGenerator<VideoFrame>;
   private videoWriter?: WritableStreamDefaultWriter<VideoFrame>;
+  private asciiElement?: HTMLElement;
+  private asciiWidth = 80;
+  private asciiHeight = 60;
   constructor(props: SubscriberInitProps) {
     this.communicator = new CommunicatorWorker();
     this.communicator.onmessage = this.communicatorMessageHandler.bind(this);
@@ -71,6 +75,11 @@ export class Subscriber {
     const stream = new MediaStream([this.videoGenerator]);
     videoElement.srcObject = stream;
     this.videoWriter = this.videoGenerator.writable.getWriter();
+  }
+  setAsciiElement(el: HTMLElement, width = 80, height = 60) {
+    this.asciiElement = el;
+    this.asciiWidth = width;
+    this.asciiHeight = height;
   }
   async setAudioContext() {
     const audioCtx = new AudioContext({ sampleRate: 48000 }); // TODO: use the sample rate from the server
@@ -268,8 +277,14 @@ export class Subscriber {
     switch (message.data.type) {
     case 'videoFrame':
       const vfData = message.data.data as { subscribeId: number, frame: VideoFrame };
+      if (this.asciiElement) {
+        const ascii = frameToAscii(vfData.frame, this.asciiWidth, this.asciiHeight);
+        this.asciiElement.textContent = ascii;
+      }
       if (this.videoWriter) {
         this.videoWriter.write(vfData.frame).then(() => vfData.frame.close());
+      } else {
+        vfData.frame.close();
       }
       break;
     case 'audioData':

--- a/client/src/lib/subscriber.ts
+++ b/client/src/lib/subscriber.ts
@@ -76,7 +76,7 @@ export class Subscriber {
     videoElement.srcObject = stream;
     this.videoWriter = this.videoGenerator.writable.getWriter();
   }
-  setAsciiElement(el: HTMLElement, width = 80, height = 60) {
+  setAsciiElement(el?: HTMLElement, width = 80, height = 60) {
     this.asciiElement = el;
     this.asciiWidth = width;
     this.asciiHeight = height;

--- a/client/src/lib/utils/ascii.ts
+++ b/client/src/lib/utils/ascii.ts
@@ -1,0 +1,24 @@
+export function frameToAscii(frame: VideoFrame, width: number, height: number): string {
+  const canvas = typeof OffscreenCanvas !== 'undefined'
+    ? new OffscreenCanvas(width, height)
+    : Object.assign(document.createElement('canvas'), { width, height });
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return '';
+  ctx.drawImage(frame as any, 0, 0, width, height);
+  const data = ctx.getImageData(0, 0, width, height).data;
+  const chars = ' .:-=+*#%@';
+  let result = '';
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const i = (y * width + x) * 4;
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      const brightness = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+      const index = Math.floor((brightness / 255) * (chars.length - 1));
+      result += chars[index];
+    }
+    result += '\n';
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- convert decoded video frames to ASCII art text
- display ASCII frames in the subscriber component

## Testing
- `npx jest` in `moqtail-core`
- `npx jest` in `bytes`
- `npx vitest run` *(fails: The requested module 'vite' does not provide an export named 'defaultClientConditions')*

------
https://chatgpt.com/codex/tasks/task_e_685032ce4d348322a27222528bbf6c32