### PR TITLE
Add basic conference demo

### DIFF
--- a/conference/README.md
+++ b/conference/README.md
@@ -1,0 +1,13 @@
+# Moqtail Conference
+
+This package provides a minimal bidirectional conferencing example using a single
+WebTransport connection. It demonstrates how to establish a connection, send the
+initial `CLIENT_SETUP` control message and react to control messages from the
+peer.  The implementation is intentionally lightweight and reuses the
+serialization helpers from `moqtail`.
+
+The demo now includes a small browser UI (`index.html`) that captures the local
+camera stream, encodes it with `VideoEncoder`, and publishes the resulting
+encoded chunks over a WebTransport unidirectional stream. Incoming streams are
+decoded with `VideoDecoder` and rendered onto a canvas element to illustrate
+basic video conferencing.

--- a/conference/index.html
+++ b/conference/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Moqtail Conference Demo</title>
+</head>
+<body>
+  <button id="start">Start Conference</button>
+  <div>
+    <video id="localVideo" autoplay muted playsinline width="320" height="240"></video>
+    <canvas id="remoteCanvas" width="320" height="240"></canvas>
+  </div>
+  <script type="module" src="./dist/app.js"></script>
+</body>
+</html>

--- a/conference/package.json
+++ b/conference/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "conference",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "node --test" 
+  },
+  "dependencies": {
+    "moqtail": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/conference/src/app.ts
+++ b/conference/src/app.ts
@@ -1,0 +1,26 @@
+import Conference from './index';
+
+const startBtn = document.getElementById('start') as HTMLButtonElement;
+const localVideo = document.getElementById('localVideo') as HTMLVideoElement;
+const remoteCanvas = document.getElementById('remoteCanvas') as HTMLCanvasElement;
+const ctx = remoteCanvas.getContext('2d');
+
+const conf = new Conference(window.location.origin);
+
+startBtn.onclick = async () => {
+  await conf.connect();
+  const stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+  localVideo.srcObject = stream;
+  await conf.publish(stream);
+};
+
+conf.onRemoteFrame = (frame: VideoFrame) => {
+  if (ctx) {
+    // draw frame to canvas and close
+    // @ts-ignore drawImage accepts VideoFrame in modern browsers
+    ctx.drawImage(frame, 0, 0);
+  }
+  frame.close();
+};
+
+export {};

--- a/conference/src/index.ts
+++ b/conference/src/index.ts
@@ -1,0 +1,195 @@
+import {
+  CONTROL_MESSAGE,
+  MOQT_DRAFT11_VERSION,
+  PARAMETER,
+  type Subscribe,
+  deserializeAnnounceError,
+  deserializeAnnounceOk,
+  deserializeServerSetup,
+  deserializeSubscribe,
+  deserializeSubscribeDone,
+  deserializeSubscribeError,
+  deserializeSubscribeOk,
+  readControlMessageType,
+  serializeAnnounce,
+  serializeClientSetup,
+  serializeSubscribe,
+  serializeUnannounce,
+  serializeUnsubscribe,
+  serializeEncodedChunk,
+  deserializeEncodedChunkFromArray
+} from 'moqtail';
+
+/**
+ * Simple conference helper that can both announce and subscribe tracks
+ * using a single WebTransport connection.
+ */
+export class Conference {
+  private wt: WebTransport | undefined;
+  private controlWriter: WritableStreamDefaultWriter<Uint8Array> | undefined;
+  private controlReader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  /** Callback for decoded remote video frames */
+  onRemoteFrame?: (frame: VideoFrame) => void;
+
+  constructor(private readonly serverUrl: string) {}
+
+  /**
+   * Establishes the WebTransport session and sends CLIENT_SETUP.
+   */
+  async connect(): Promise<void> {
+    this.wt = new WebTransport(this.serverUrl, { congestionControl: 'throughput' });
+    await this.wt.ready;
+    const control = await this.wt.createBidirectionalStream();
+    this.controlWriter = control.writable.getWriter();
+    this.controlReader = control.readable.getReader();
+
+    const setup = serializeClientSetup({
+      supportedVersions: [MOQT_DRAFT11_VERSION],
+      params: [{ type: PARAMETER.SETUP.MAX_REQUEST_ID.KEY, value: 1000 }]
+    });
+    await this.controlWriter.write(setup);
+    // Start loops for control messages and incoming media streams
+    this.readLoop();
+    this.handleIncomingStreams();
+  }
+
+  /**
+   * Announces a namespace to other participants.
+   */
+  async announce(requestId: number, namespace: string[]): Promise<void> {
+    if (!this.controlWriter) throw new Error('not connected');
+    const msg = serializeAnnounce({ requestId, trackNamespace: namespace, parameters: [] });
+    await this.controlWriter.write(msg);
+  }
+
+  /**
+   * Subscribes to a track.
+   */
+  async subscribe(props: Subscribe): Promise<void> {
+    if (!this.controlWriter) throw new Error('not connected');
+    const msg = serializeSubscribe(props);
+    await this.controlWriter.write(msg);
+  }
+
+  /**
+   * Unsubscribes from a track by request id.
+   */
+  async unsubscribe(requestId: number): Promise<void> {
+    if (!this.controlWriter) throw new Error('not connected');
+    const msg = serializeUnsubscribe(requestId);
+    await this.controlWriter.write(msg);
+  }
+
+  /**
+   * Withdraws a previous ANNOUNCE.
+   */
+  async unannounce(namespace: string[]): Promise<void> {
+    if (!this.controlWriter) throw new Error('not connected');
+    const msg = serializeUnannounce({ trackNamespace: namespace });
+    await this.controlWriter.write(msg);
+  }
+
+  /**
+   * Publishes a local video track over a new unidirectional stream.
+   */
+  async publish(stream: MediaStream): Promise<void> {
+    if (!this.wt) throw new Error('not connected');
+    const track = stream.getVideoTracks()[0];
+    const processor = new MediaStreamTrackProcessor({ track });
+    const reader = processor.readable.getReader();
+
+    const wtStream = await this.wt.createUnidirectionalStream();
+    const writer = wtStream.getWriter();
+
+    const settings = track.getSettings();
+    const encoder = new VideoEncoder({
+      output: async (chunk) => {
+        const data = serializeEncodedChunk(chunk);
+        await writer.write(data);
+      },
+      error: e => console.error('encoder error', e)
+    });
+    encoder.configure({
+      codec: 'vp8',
+      width: settings.width || 640,
+      height: settings.height || 480
+    });
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      encoder.encode(value);
+      value.close();
+    }
+    await writer.close();
+  }
+
+  /**
+   * Reads control messages indefinitely and logs basic events.
+   */
+  private async readLoop(): Promise<void> {
+    if (!this.controlReader) return;
+    while (true) {
+      const type = await readControlMessageType(this.controlReader);
+      switch (type) {
+        case CONTROL_MESSAGE.SERVER_SETUP:
+          await deserializeServerSetup(this.controlReader);
+          break;
+        case CONTROL_MESSAGE.ANNOUNCE_OK:
+          await deserializeAnnounceOk(this.controlReader);
+          break;
+        case CONTROL_MESSAGE.ANNOUNCE_ERROR:
+          await deserializeAnnounceError(this.controlReader);
+          break;
+        case CONTROL_MESSAGE.SUBSCRIBE:
+          // For conferencing, we simply log incoming subscribes. In a full
+          // application this would trigger media forwarding logic.
+          await deserializeSubscribe(this.controlReader);
+          break;
+        case CONTROL_MESSAGE.SUBSCRIBE_OK:
+          await deserializeSubscribeOk(this.controlReader);
+          break;
+        case CONTROL_MESSAGE.SUBSCRIBE_ERROR:
+          await deserializeSubscribeError(this.controlReader);
+          break;
+        case CONTROL_MESSAGE.SUBSCRIBE_DONE:
+          await deserializeSubscribeDone(this.controlReader);
+          break;
+        default:
+          // Ignore other control messages for brevity
+          return;
+      }
+    }
+  }
+
+  /**
+   * Reads any incoming unidirectional streams and decodes video chunks.
+   */
+  private async handleIncomingStreams(): Promise<void> {
+    if (!this.wt) return;
+    const reader = this.wt.incomingUnidirectionalStreams.getReader();
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      this.handleIncomingStream(value);
+    }
+  }
+
+  private async handleIncomingStream(stream: ReadableStream<Uint8Array>): Promise<void> {
+    const reader = stream.getReader();
+    const decoder = new VideoDecoder({
+      output: frame => this.onRemoteFrame?.(frame),
+      error: e => console.error('decoder error', e)
+    });
+    decoder.configure({ codec: 'vp8' });
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      const init = deserializeEncodedChunkFromArray(value);
+      const chunk = new EncodedVideoChunk(init);
+      decoder.decode(chunk);
+    }
+  }
+}
+
+export default Conference;

--- a/conference/tsconfig.json
+++ b/conference/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["es2022", "dom", "dom.iterable"]
+  },
+  "include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "moqtail-root",
   "workspaces": [
     "client",
+    "conference",
     "moqtail-core",
     "bytes"
   ]


### PR DESCRIPTION
## Summary
- add simple browser UI for the `conference` workspace to capture local camera and display remote video
- extend `Conference` helper with video encoding/decoding via WebCodecs and WebTransport streams
- document the conferencing demo

## Testing
- `npm test --workspaces` *(fails: The requested module 'vite' does not provide an export named 'defaultClientConditions')*


------
https://chatgpt.com/codex/tasks/task_e_6895874fb8308322aad7941d6c3222ee